### PR TITLE
typo fix `DSOnlySelf`

### DIFF
--- a/contracts/util/modifiers.sol
+++ b/contracts/util/modifiers.sol
@@ -17,7 +17,7 @@ contract DSOnlyIf {
         }
     }
 }
-contract DSOnlySelf() {
+contract DSOnlySelf {
     modifier only_self() {
         if( msg.sender == address(this) ) {
             _


### PR DESCRIPTION
Hi, I was going through the [token tutorial](https://github.com/nexusdev/dapple/blob/master/doc/tutorials/token.md) and got an error.

```
dapple-test/dapple_packages/dappsys/contracts/util/modifiers.sol:20:19: Error: Expected token LBrace got 'RParen'
contract undefined) {
                  ^
```

Seems like it was caused by a typo, which is fixed in this PR.